### PR TITLE
Typescript fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ interface ServerOptions {
     serverOptions?: protocolServerOptions;
     clientOptions?: Partial<protocolClientOptions>;
 }
-interface ProxyEvents {
+type ProxyEvents = {
     incoming: (data: any, meta: PacketMeta, toClient: ServerClient, toServer: Client) => void;
     outgoing: (data: any, meta: PacketMeta, toClient: ServerClient, toServer: Client) => void;
     start: (toClient: ServerClient, toServer: Client) => void;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "debug": "^4.3.1",
     "minecraft-data": "^2.94.0",
     "minecraft-packets": "^1.5.0",
-    "minecraft-protocol": "^1.13.0"
+    "minecraft-protocol": "^1.13.0",
+    "typed-emitter": "^2.1.0"
   }
 }


### PR DESCRIPTION
Fixed issue where proxy.on was undefinded.
Cause: 
typed-emtter was missing as a dependency
and the proxyEvents interface needed to be a type instead 