### PR TITLE
Fixed version map & updated README.md & updated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ This is a proxy that will allow you to instantly connect to the target, so you w
 ```js
 const { InstantConnectProxy } = require('prismarine-proxy')
 
-const login = ['my@email.com', 'mypassword']
+const login = 'my@email.com' // microsoft email or minecraft username
 
 const proxy = new InstantConnectProxy({
   loginHandler: (client) => { // client object has a username object, so you can store usernames with their respective logins
-    return { username: login[0], password: login[1] } // the login the proxy will connect to the server with
+    return { username: login, auth: 'microsoft' } // the login the proxy will connect to the server with
   },
   serverOptions: { // options for the local server shown to the vanilla client
     version: '1.8.9'
@@ -58,6 +58,4 @@ proxy.on('outgoing', (data, meta, toClient, toServer) => { // packets outgoing f
 })
 ```
 
-Information about packets can be found [here](https://minecraft-data.prismarine.js.org/), make sure to select the minecraft version at the top, then click protocol.
-
-More info about packets can be found [here](https://wiki.vg/Protocol), make sure to select the version you are working with
+Information about packets can be found [here](https://prismarinejs.github.io/minecraft-data/), make sure to select the minecraft version at the top, then click protocol.

--- a/examples/instant_connect_example.js
+++ b/examples/instant_connect_example.js
@@ -1,8 +1,8 @@
 const { InstantConnectProxy } = require('prismarine-proxy')
 const proxy = new InstantConnectProxy({
   loginHandler: (client) => {
-    if (client.username === 'U9G') return { username: 'john' }
-    else return { username: client.username }
+    if (client.username === 'U9G') return { username: 'john', auth: 'microsoft' }
+    else return { username: client.username, auth: 'microsoft' }
   },
   clientOptions: {
     host: 'localhost',

--- a/src/instant_connect_proxy.js
+++ b/src/instant_connect_proxy.js
@@ -4,8 +4,7 @@ const packets = require('minecraft-packets').pc
 const mcDataLoader = require('minecraft-data')
 const PLAY_STATE = 'play'
 const verMap = {
-  '1.8.8': '1.8',
-  '1.8.9': '1.8'
+  '1.8.9': '1.8.8'
 }
 
 function getPacket (ver, name, mcData) {


### PR DESCRIPTION
The version map now maps 1.8.9 to 1.8.8 instead of 1.8 as the folder was renamed in the minecraft-packets repository.

The examples in the README.md and examples/instant_connect_example.js now use microsoft authentication instead of
username+password as they are deprecated.

Removed wiki.vg link from README.md as the website is discontinued.